### PR TITLE
Fixes excerpts not being used as description

### DIFF
--- a/classes/loading.php
+++ b/classes/loading.php
@@ -36,6 +36,7 @@ class Loading {
 			new Admin\Box();
 		} else {
 			new Thumbs();
+			new Particular();
 		}
 	}
 	/**


### PR DESCRIPTION
There's an issue with excerpts not being used despite having 'yes' in the JM Twitter Cards setting. (see: https://wordpress.org/support/topic/twitter-cards-excerpts-not-working/)

It looks like you're not initialising the `Particular` class, therefore the filter on `jm_tc_get_excerpt` is not getting added.

This PR will initialise the `Particular` class in the `plugin_setup` method.